### PR TITLE
docs: Clarify .dagger/ as optional orchestration module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ dagger install [options] <module>
 
 ### Directory Structure
 
-- **`.dagger/`** - Optional orchestration module. Use `dagger install` here to compose multiple modules, or create dedicated wrapper modules elsewhere as needed.
+- **`.dagger/`** - Optional orchestration module. Use `dagger install` here to compose multiple modules, or create dedicated wrapper modules elsewhere. Project CI may also live here.
 - **Individual module directories** - Each module lives in its own directory at the repo root.
 
 ## Import Path


### PR DESCRIPTION
Update directory structure description to be more flexible:

- Make it clear .dagger/ is optional, not mandatory
- Mention dagger install for composing modules
- Suggest wrapper modules as alternative approach
- Remove prescriptive "call and test" language

Written for busy readers with succinct, practical guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)