### PR TITLE
docs: Add useful Dagger documentation links to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,3 +180,8 @@ func (m *MyModule) Deploy(
     // No need for: if environment == "" { environment = "production" }
 }
 ```
+
+## Useful Links
+
+- [Dagger Go SDK API Reference](https://pkg.go.dev/dagger.io/dagger)
+- [Dagger Documentation](https://docs.dagger.io/llms.txt)


### PR DESCRIPTION
Add references to the Dagger Go SDK API docs and main documentation at the bottom of the file for quick reference.

Generated with [Claude Code](https://claude.com/claude-code)